### PR TITLE
Update Go version to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module arnested.dk/go/triagebot
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/andygrunwald/go-jira v1.17.0


### PR DESCRIPTION
Update Go version to 1.26.3.

See [the release history](https://go.dev/doc/devel/release#go1.26.3).